### PR TITLE
Using hyphen instead of whitespace

### DIFF
--- a/xkcdgen.js
+++ b/xkcdgen.js
@@ -237,7 +237,7 @@ function generatepass(plength) {
     for (i = 0; i < iterSize; i++) {
         randomNum = Math.floor(Math.random() * arraySize)
         string = words[randomNum]
-        passphrase += ' ' + string
+        passphrase += '-' + string
     }
     return passphrase
 }


### PR DESCRIPTION
Most websites [require](https://github.com/apple/password-manager-resources/blob/main/quirks/password-rules.json) at least one number or special character to be used in passwords, so I think It would be better to put hyphen ("-") instead of whitespace (" ") between the words.